### PR TITLE
Fix generation of listings and add 'make clean'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,14 @@ SAMPLES = $(addprefix $(OUT_DIR)/, kv0.rad-tex kv1.rad-tex repl.rad-tex currency
 .PHONY: ALL
 all: $(SAMPLES) LATEX
 
+clean:
+	rm $(SAMPLES)
+	rm out/oscoin.pdf
+
 $(SAMPLES): $(OUT_DIR)/%.rad-tex : $(SAMPLE_DIR)/%.rad
-	echo '\\begin{lstlisting}' > $@
+	echo '\begin{lstlisting}' > $@
 	cat $^ >> $@
-	echo '\\end{lstlisting}' >> $@
+	echo '\end{lstlisting}' >> $@
 
 .PHONY: LATEX
 LATEX:


### PR DESCRIPTION
Before, the `rad-tex` files contained double backslashes and broke compilation.

Also adds `make clean`